### PR TITLE
Add Xinfra Monitor

### DIFF
--- a/kafka-links.csv
+++ b/kafka-links.csv
@@ -91,6 +91,7 @@ CruiseControl;https://github.com/linkedin/cruise-control
 kafkacat;https://github.com/edenhill/kafkacat
 Kafka Lag Exporter;https://github.com/lightbend/kafka-lag-exporter
 topicctl;https://github.com/segmentio/topicctl
+Xinfra Monitor;https://github.com/linkedin/kafka-monitor
 ## k8s Operators
 Confluent Operator;https://docs.confluent.io/operator/current/overview.html
 Banzai Cloud Kafka Operator;https://github.com/banzaicloud/kafka-operator


### PR DESCRIPTION
This PR adds Xinfra Monitor as a resource reference under the Tool section.

[Xinfra Monitor](https://github.com/linkedin/kafka-monitor)  is a framework to implement and execute long-running Kafka system tests in a real cluster. It complements Kafka’s existing system tests by capturing potential bugs or regressions that are only likely to occur after a prolonged period of time or with low probability.