### PR TITLE
Keep link color when visited

### DIFF
--- a/Convert.java
+++ b/Convert.java
@@ -16,9 +16,9 @@ public class Convert {
     private static final Pattern SEPARATOR = Pattern.compile(";");
 
     private static String styles = """
-                                   a {
+                                   a, a:visited {
                                      text-decoration: underline;
-                                     fill: 0077cc;
+                                     fill: #0077cc;
                                    }
                                    """;
 

--- a/docs/kafka.svg
+++ b/docs/kafka.svg
@@ -11,9 +11,9 @@
         font-family: "Cascadia";
         src: url("https://excalidraw.com/Cascadia.woff2");
       }
-    a {
+    a, a:visited {
   text-decoration: underline;
-  fill: 0077cc;
+  fill: #0077cc;
 }
 </style>
   </defs>


### PR DESCRIPTION
Many THX for the suggested fixes @mabulgu

1) @gunnarmorling decided that links shouldn't open in a new tab per default which is why I removed this change.

2) I slightly modified your suggested color-related changes because for me, the link coloring didn't work correctly after testing it with 3 browsers FF,Chrome,Safari on Mac OS.